### PR TITLE
Add Python3 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*__pycache__
+*.pyc
+src/_trial_temp*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ sudo: false
 dist: trusty
 language: python
 python:
-  - 2.7
-services: rabbitmq
-install: pip install -r requirements.txt
-script: cd src; TXAMQP_BROKER=RABBITMQ trial txamqp
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+services:
+  - rabbitmq
+install: "pip install -r requirements.txt"
+script: "cd src; TXAMQP_BROKER=RABBITMQ trial txamqp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
 services:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ except ImportError:
 else:
     setupdict['packages'] = find_packages('src')
     setupdict['package_dir'] = { '': 'src' }
-    setupdict['install_requires'] = ['Twisted']
-        
+    setupdict['install_requires'] = ['Twisted', 'six']
+
 setup(**setupdict)

--- a/src/txamqp/delegate.py
+++ b/src/txamqp/delegate.py
@@ -18,7 +18,7 @@
 #
 
 import inspect
-from spec import pythonize
+from .spec import pythonize
 
 class Delegate(object):
 

--- a/src/txamqp/endpoint.py
+++ b/src/txamqp/endpoint.py
@@ -80,21 +80,21 @@ class AMQEndpoint(object):
 
         @see: https://www.rabbitmq.com/uri-spec.html
         """
-        uri = URI.fromBytes(uri, defaultPort=5672)
+        uri = URI.fromBytes(uri.encode(), defaultPort=5672)
         kwargs = {}
-        host = uri.host
+        host = uri.host.decode()
         if "@" in host:
-            auth, host = uri.netloc.split("@")
+            auth, host = uri.netloc.decode().split("@")
             username, password = auth.split(":")
             kwargs.update({"username": username, "password": password})
 
-        vhost = uri.path
+        vhost = uri.path.decode()
         if len(vhost) > 1:
             vhost = vhost[1:]  # Strip leading "/"
         kwargs["vhost"] = vhost
 
         params = parse_qs(uri.query)
-        kwargs.update({name: value[0] for name, value in params.items()})
+        kwargs.update({name.decode(): value[0].decode() for name, value in params.items()})
 
         if "heartbeat" in kwargs:
             kwargs["heartbeat"] = int(kwargs["heartbeat"])

--- a/src/txamqp/spec.py
+++ b/src/txamqp/spec.py
@@ -29,7 +29,7 @@ class so that the generated code can be reused in a variety of
 situations.
 """
 
-import re, textwrap, new, os
+import re, textwrap, types, os
 
 from txamqp import xmlutil
 
@@ -48,12 +48,12 @@ class SpecContainer(object):
     self.bypyname = {}
 
   def add(self, item):
-    if self.byname.has_key(item.name):
+    if item.name in self.byname:
       raise ValueError("duplicate name: %s" % item)
-    if self.byid.has_key(item.id):
+    if item.id in self.byid:
       raise ValueError("duplicate id: %s" % item)
     pyname = pythonize(item.name)
-    if self.bypyname.has_key(pyname):
+    if pyname in self.bypyname:
       raise ValueError("duplicate pyname: %s" % item)
     self.indexes[item] = len(self.items)
     self.items.append(item)
@@ -111,7 +111,7 @@ class Spec(Metadata):
     return self.classes.byname[klass].methods.byname[meth]
 
   def define_module(self, name, doc = None):
-    module = new.module(name, doc)
+    module = types.ModuleType(name, doc)
     module.__file__ = self.file
     for c in self.classes:
       classname = pythonize(c.name)
@@ -221,7 +221,7 @@ class Method(Metadata):
     if self.content:
       code += ", content"
     code += ")"
-    exec code in g, l
+    exec(code, g, l)
     return l[name]
 
 class Field(Metadata):
@@ -244,7 +244,7 @@ def load_fields(nd, l, domains):
       type = f_nd["@domain"]
     except KeyError:
       type = f_nd["@type"]
-    while domains.has_key(type) and domains[type] != type:
+    while type in domains and domains[type] != type:
       type = domains[type]
     l.add(Field(f_nd["@name"], f_nd.index(), type, get_docs(f_nd)))
 
@@ -369,4 +369,4 @@ def test_summary():
     rows.append('<tr><td colspan="3">%s</td></tr>' % rule.text)
     rows.append('<tr><td colspan="3">&nbsp;</td></tr>')
 
-  print template % "\n".join(rows)
+  print(template % "\n".join(rows))

--- a/src/txamqp/test/test_queue.py
+++ b/src/txamqp/test/test_queue.py
@@ -198,7 +198,7 @@ class QueueTests(TestBase):
         yield channel.channel_open()
         try:
             result = yield channel.queue_delete(queue="i-dont-exist", if_empty="True")
-            print result
+            print(result)
             self.fail("Expected delete of non-existant queue to fail")
         except Closed as e:
             self.assertChannelException(404, e.args[0])

--- a/src/txamqp/test/test_testlib.py
+++ b/src/txamqp/test/test_testlib.py
@@ -30,7 +30,7 @@ from twisted.internet.defer import inlineCallbacks
 
 def mytrace(frame, event, arg):
     print_stack(frame);
-    print "===="
+    print("====")
     return mytrace
     
 class TestBaseTest(TestBase):

--- a/src/txamqp/testing.py
+++ b/src/txamqp/testing.py
@@ -111,7 +111,7 @@ class AMQPump(object):
         klass = self._classFromPyName(klass)
         method = self._methodFromPyName(klass, method)
         args = [None] * len(method.fields.items)
-        for key, value in fields.iteritems():
+        for key, value in fields.items():
             field = method.fields.bypyname[key]
             args[method.fields.indexes[field]] = value
         self.pump(channel, Method(method, *args))

--- a/src/txamqp/testlib.py
+++ b/src/txamqp/testlib.py
@@ -117,8 +117,8 @@ class TestBase(unittest.TestCase):
         c = reactor.connectTCP(host, port, f)
         def errb(thefailure):
             thefailure.trap(error.ConnectionRefusedError)
-            print "failed to connect to host: %s, port: %s; These tests are designed to run against a running instance" \
-                  " of the %s AMQP broker on the given host and port.  failure: %r" % (host, port, self.broker, thefailure,)
+            print("failed to connect to host: %s, port: %s; These tests are designed to run against a running instance" \
+                  " of the %s AMQP broker on the given host and port.  failure: %r" % (host, port, self.broker, thefailure,))
             thefailure.raiseException()
         onConn.addErrback(errb)
 
@@ -136,7 +136,7 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         try:
             self.client = yield self.connect()
-        except txamqp.client.Closed, le:
+        except txamqp.client.Closed as le:
             le.args = tuple(("Unable to connect to AMQP broker in order to run tests (perhaps due to auth failure?). " \
                 "The tests assume that an instance of the %s AMQP broker is already set up and that this test script " \
                 "can connect to it and use it as user '%s', password '%s', vhost '%s'." % (_get_broker(),

--- a/src/txamqp/xmlutil.py
+++ b/src/txamqp/xmlutil.py
@@ -75,7 +75,7 @@ class Node(object):
 
   def __getitem__(self, key):
     if callable(key):
-      return filter(key, self.children)
+      return list(filter(key, self.children))
     else:
       t = key.__class__
       meth = "__get%s__" % t.__name__


### PR DESCRIPTION
Hey, I thought seeing as Twisted has ported a large majority of code to Python3 this library could benefit from it as well.

First of all, sorry for the large patch of small changes. I've converted the main library to be compatible with both Python2 and Python3, hope that's OK :wink:. I haven't updated the `examples`, `setup.py` to include the six dependancy (though Twisted also depends on it) or the `.travis.yml` to run both Python2 and Python3 tests, if your happy with this PR I'll also commit those changes.

Have run the test cases for both Python2 and Python3, all unit tests that use RabbitMQ pass (the other ones were skipped.

## Test Results: 
[txamqp-test-python2.txt](https://github.com/txamqp/txamqp/files/1123133/txamqp-test-python2.txt)
[txamqp-test-python3.txt](https://github.com/txamqp/txamqp/files/1123135/txamqp-test-python3.txt)

As far as I'm aware the code has not changed functionally (excluding the 2 method that handle actual binary data), from the end users view it should act exactly as expected.

## File by file change overview:
### codec.py
* Swapped out StringIO with BytesIO
* Created dedicated enc/dec functions to handle actual binary data, then the current enc/dec string methods take care of strings
* Changed some strings in enc/dec table methods to byte strings for byte == byte comparisons
* Swapped out xrange for range (could of used six.moves.range)

### connection.py
* Swapped out StringIO with BytesIO
* Changed relative import syntax
* Used six's cross version metaclass compatibility
* Changed the enc/dec methods in Method to use encode_longbytes and decode_longbytes

### delegate.py
* Changed relative import syntax

### endpoint.py
* URI.fromBytes really wants bytes not unicode so did some .encodes and .decodes to keep it happy

### protocol.py
* Swapped out StringIO with BytesIO
* Changed except syntax to except as
* Swapped out xrange for range (could of used six.moves.range)
* Changed FrameReceiver.__buffer to a bytestring so then += still works
* Changed "AMQP" to a bytestring b"AMQP"
* In readContent I replaced StringIO with six.StringIO as io.StringIO is not the same as StringIO.StringIO in Python2 and this retains expected behaviour

### spec.py
* Replaced module creation code with the types.ModuleType way which is cross version
* Replaced "dict.has_key" with "key in dict"
* Changed exec to its functional equivelent
* Changed print to its functional equivelent

### testing.py
* Changed iteritems to items
* Changed print to its functional equivelent
* Changed except syntax to except as

### testlib.py
* Surrounded filter with list as the result gets indexed and Python3's filter returns an iterator

### test/test_queue.py
* Changed print to its functional equivelent, arguably the print in this file is unnecessary

### test/test_testlib.py
* Changed print to its functional equivelent, arguably the print in this file is unnecessary