### PR TITLE
Take care of unicode in Content properties + tests

### DIFF
--- a/src/txamqp/codec.py
+++ b/src/txamqp/codec.py
@@ -203,7 +203,8 @@ class Codec(object):
         codec = Codec(enc)
         for key, value in tbl.items():
             codec.encode_shortstr(key)
-            if isinstance(value, str):
+            # Convert everything to binary representation (aka python3 string, and python2 unicode)
+            if isinstance(value, str) or (six.PY2 and isinstance(value, unicode)):
                 codec.write(b"S")
                 codec.encode_longstr(value)
             else:

--- a/src/txamqp/test/test_basic.py
+++ b/src/txamqp/test/test_basic.py
@@ -479,6 +479,7 @@ class BasicTests(TestBase):
     def test_get_binary(self):
         """
         Test basic_get method
+        Refs #4
         """
         channel = self.channel
         yield channel.queue_declare(queue="test-get-bin", exclusive=True)
@@ -498,6 +499,28 @@ class BasicTests(TestBase):
             self.assertEqual(reply.method.klass.name, "basic")
             self.assertEqual(reply.method.name, "get-ok")
             self.assertEqual("Message %d" % i, pickle.loads(reply.content.body))
+
+    @inlineCallbacks
+    def test_get_properties_with_unicode(self):
+        """
+        Test basic_get method with a property having unicode content
+        Refs #4
+        """
+        channel = self.channel
+        yield channel.queue_declare(queue="test-get-header-unicode", exclusive=True)
+
+        # publish a message (no_ack=True) with persistent messaging
+        msg = Content("some value")
+        msg["delivery mode"] = 2
+        msg['headers'] = {"somekey": unicode(u"any thing in unicode")}
+        channel.basic_publish(routing_key="test-get-header-unicode", content=msg)
+
+        # use basic_get to read back the messages, and check that we get an empty at the end
+        reply = yield channel.basic_get(no_ack=True)
+        self.assertEqual(reply.method.klass.name, "basic")
+        self.assertEqual(reply.method.name, "get-ok")
+        self.assertEqual("some value", reply.content.body)
+        self.assertEqual({"somekey": unicode(u"any thing in unicode")}, reply.content.properties['headers'])
 
     @inlineCallbacks
     def test_fragment_body(self):

--- a/src/txamqp/test/test_basic.py
+++ b/src/txamqp/test/test_basic.py
@@ -512,7 +512,7 @@ class BasicTests(TestBase):
         # publish a message (no_ack=True) with persistent messaging
         msg = Content("some value")
         msg["delivery mode"] = 2
-        msg['headers'] = {"somekey": unicode(u"any thing in unicode")}
+        msg['headers'] = {"somekey": u"any thing in unicode"}
         channel.basic_publish(routing_key="test-get-header-unicode", content=msg)
 
         # use basic_get to read back the messages, and check that we get an empty at the end
@@ -520,7 +520,7 @@ class BasicTests(TestBase):
         self.assertEqual(reply.method.klass.name, "basic")
         self.assertEqual(reply.method.name, "get-ok")
         self.assertEqual("some value", reply.content.body)
-        self.assertEqual({"somekey": unicode(u"any thing in unicode")}, reply.content.properties['headers'])
+        self.assertEqual({"somekey": u"any thing in unicode"}, reply.content.properties['headers'])
 
     @inlineCallbacks
     def test_fragment_body(self):


### PR DESCRIPTION
Unicode values in Content properties were not encoded correctly in py2